### PR TITLE
Update contributing docs from maintenance swarm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,22 @@ You'll want to learn more about how Learning Lab works and courses are structure
 - watch the [video on how a Learning Lab course works](https://www.youtube.com/watch?v=xaLSVcwFkiI&list=PLg7s6cbtAD147DXcVp899Fk6SegoLY9gL&index=4)
 - watch the [video on the `config.yml`](https://www.youtube.com/watch?v=HL8MdBsFaF4&list=PLg7s6cbtAD147DXcVp899Fk6SegoLY9gL&index=2)
 
+### Finding open issues
+
+The [course maintenance project board](https://github.com/orgs/githubtraining/projects/1) is the place to go if you want to contribute but aren't sure _what_ to do. The project board is the unifying place to find bug reports, fixes, and course enhancements across all of the GitHub authored Learning Lab courses. It may be used in several ways:
+
+#### A new issue is opened
+
+When a new issue is opened in any of the course or template repositories for GitHub authored Learning Lab courses, they should be moved to the `Triage` column. This creates visibility for the issue.
+
+#### Triaging existing issues
+
+Maintainers of Learning Lab courses may use this board to triage existing issues. When triaging, maintainers evaluate the issue and fit it into the column that is most appropriate. The columns are sorted via priority, with highest priority issues at the top, but currently the system for determining priority is fluid.
+
+#### Finding somewhere to contribute
+
+If you want to contribute, but aren't sure how or where to start, the project board is a perfect place. You can see all of the open issues in one place. Aside from opening an issue, the main ways of contributing are to [replicate bug reports](how_to_replicate.md), [open pull requests](CONTRIBUTING.md) addressing open issues, or [reviewing open pull requests](how_to_review.md).
+
 ### How to Contribute
 
 1. Fork the course repository AND the template repository.
@@ -38,4 +54,5 @@ You'll want to learn more about how Learning Lab works and courses are structure
 1. Open a pull request in the parent repository with:
     - base branch: the default branch of the course repository, usually `main`
     - compare branch: the branch containing your commits in your fork
+    - Note: If a pull request is created from a fork, then Learning Lab will not deploy a version of that course. Please ping a member of @githubtraining/programs for help. They will merge the pull request into a different branch (_not the default or original target branch_) and open a new pull request that will trigger a build of the course that can be manually tested.
 1. Request a review from the Learning Lab team (this should be automatically requested)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ You can find all of our open source courses by [selecting the `learning-lab` top
 
 ### Contributing to a course
 
-Check out the [contributing guide](CONTRIBUTING.md) in this repository for more information on how you can contribute to these courses. 
+Check out the [contributing guide](CONTRIBUTING.md) in this repository for more information on how you can contribute to these courses.
+
+The [course maintenance project board](https://github.com/orgs/githubtraining/projects/1) features open issues and pull requests. Look here if you want to contribute, but aren't sure where to start. The [contributing guide](CONTRIBUTING.md) also features details about how to interact with this project board.
 
 ### Contributing a new bot behavior
 

--- a/how_to_replicate.md
+++ b/how_to_replicate.md
@@ -1,0 +1,24 @@
+# Replicating bugs
+
+This document outlines the "who", the "why", and the "how" for replicating issues from the _Needs to be replicated_ column of the [Learning Lab course maintenance project board](https://github.com/orgs/githubtraining/projects/1).
+
+## Who?
+
+If you are able to complete the Learning Lab course in question, then you are able to contribute by replicating bugs! This is a great way to contribute even if you aren't ready to submit a pull request.
+
+## Why?
+
+We frequently get reports of bugs from the community. Frequently, when something is broken, we receive multiple reports. But, sometimes we only get one report. Before investing the time in fixing these bugs, we want to confirm a few things.
+
+- Confirm that bug is with the Learning Lab course, not other systems
+- Understand the scope, impact, and detail of the bug
+
+Once we have this information, we are prepared to either close the issue or move the issue to another column so that it can be fixed.
+
+## How?
+
+1. Read the issue
+2. Sign up for the course in question, and try to duplicate the original user's situation
+3. Document your experience in detail around the steps where the original user encountered problems
+4. Share your notes, screenshots, and any additional detail or context in that issue and mention @githubtraining/programs
+5. Someone from the @githubtraining/programs team will move this from the **Needs review** column to a more appropriate column. If you'd like to address the issue, please feel free to go ahead and open a pull request - no need to wait for it to be triaged!

--- a/how_to_review.md
+++ b/how_to_review.md
@@ -1,0 +1,24 @@
+# How to review
+
+This document outlines the steps to review a pull request in a GitHub authored Learning Lab course repository. You can find pull requests awaiting review in the "Needs review" column of the [Learning Lab maintenance project board](https://github.com/orgs/githubtraining/projects/1).
+
+Guidelines for review are based on the type of changes in the pull request:
+
+#### Minor markdown changes
+
+If a pull request is only editing minor markdown responses, (like correcting a spelling error or broken URL,) then going through the entire course to review is not necessary. These pull requests can be reviewed simply by viewing and reading the files changed. If this is the case, consider the context of the course as well as the original issue reporting a bug or requesting a change.
+
+#### Moderate to significant markdown changes
+
+If a pull request introduces moderate to significant changes to markdown, a manual review of the course is necessary. Examples of moderate to significant changes could be:
+
+- Changing the instructions of a step in a way that would cause the learner to do something different
+- Changing responses that include liquid syntax or other variables outside of [GitHub flavored markdown](https://github.github.com/gfm/)
+
+#### `config.yml` changes
+
+If a pull request changes the `config.yml` file, a manual review is always required.
+
+### Manual testing
+
+Only members with specific permission are currently able to manually review the versions of courses that are deployed from pull requests. If you are a regular contributor and would like this access, please contact @githubtraining/programs.

--- a/updating_templates.md
+++ b/updating_templates.md
@@ -1,0 +1,23 @@
+# Updating template repositories
+
+Updating template repositories is particularly tricky, because there is distinct history on each branch plotted intentionally to be ready for the pull requests that a learner may interact with. For this reason, contributions to the template repository should be managed by the @githubtraining/programs team in most cases.
+
+## Syncing the course repository
+
+In any case where a course repository is updated, a member of @githubtraining/programs will need to manually sync the template repository to the course via Learning Lab stafftools.
+
+## Updates not affecting activities
+
+If you need to make a change to a template repository that does not affect the branches or activities, please commit directly to master.
+
+## Updates affecting activities
+
+Changes on branches affecting activities can be complex and difficult. Template repositories cannot be synced to some versions of a course, and not others. **In these cases, it may be useful to create a fork of template repository to test separately and completely.** 
+
+1. If you do this, update the link to the template repository from the course repository's `config.yml` file.
+2. Then, you can test the course from a branch with a separate template repository. Make any necessary changes to the _forked_ version of the template repository, and test.
+3. Once things work as expected, force push all branches from the fork to the upstream repository.
+4. **Important**: update the reference in the course repository's `config.yml` file back to the original template repository.
+5. Delete the fork of the template repository.
+6. Test again from the branch deployment.
+7. After merging the pull request, test once more from the published and public version of the course.


### PR DESCRIPTION
This pull request adds and updates documentation for contributing to Learning Lab courses based on our maintenance swarm.

So far, it adds:

- Docs on the project board
- How to replicate
- How to test

We can either keep this open to keep adding throughout the week, or merge it in now and open a new branch. @hectorsector What do you think?

cc @githubtraining/learning-lab-reviewers @githubtraining/programs 